### PR TITLE
ロボットシリアル通信の動作確認後の修正

### DIFF
--- a/lib/RobotReceiver/examples/test_RobotReceiver/test_RobotReceiver.cpp
+++ b/lib/RobotReceiver/examples/test_RobotReceiver/test_RobotReceiver.cpp
@@ -3,9 +3,7 @@
 
 #include "RobotReceiver.h"
 
-#define ESP_MODE
-
-#ifdef ESP_MODE
+#ifdef ESP32
 EspSoftwareSerial::UART mySerial;
 #else
 SoftwareSerial mySerial(12, 11);
@@ -18,8 +16,8 @@ void setup()
 {
     // シリアルポート初期化
     Serial.begin(115200);
-#ifdef ESP_MODE
-    mySerial.begin(115200, EspSoftwareSerial::SWSERIAL_8N1, 22, 23);
+#ifdef ESP32
+    mySerial.begin(115200, EspSoftwareSerial::SWSERIAL_8N1, 12, 11);
 #else
     mySerial.begin(115200);
 #endif
@@ -43,9 +41,18 @@ void loop()
       {
         digitalWrite(19, LOW);        
       }
-      Serial.print("turn:");
-      Serial.println(rr.commands.turn);
 
+      Serial.print("fb: "); Serial.print(rr.commands.fb); Serial.print(" ");
+      Serial.print("lr: "); Serial.print(rr.commands.lr); Serial.print(" ");
+      Serial.print("tr: "); Serial.print(rr.commands.turn); Serial.print(" ");
+      Serial.print("up: "); Serial.print(rr.commands.up); Serial.print(" ");
+      Serial.print("ri: "); Serial.print(rr.commands.right); Serial.print(" ");
+      Serial.print("do: "); Serial.print(rr.commands.down); Serial.print(" ");
+      Serial.print("le: "); Serial.print(rr.commands.left); Serial.print(" ");
+      Serial.print("sq: "); Serial.print(rr.commands.square); Serial.print(" ");
+      Serial.print("cr: "); Serial.print(rr.commands.cross); Serial.print(" ");
+      Serial.print("ci: "); Serial.print(rr.commands.circle); Serial.print(" ");
+      Serial.print("tr: "); Serial.print(rr.commands.triangle); Serial.println(" ");
     }
     
     // 待ち時間

--- a/lib/RobotReceiver/platformio.ini
+++ b/lib/RobotReceiver/platformio.ini
@@ -19,5 +19,18 @@ lib_extra_dirs =
     ..
 lib_deps = 
     RobotReceiver
-    RobTillaart/CRC@^1.0.1 
+    RobTillaart/CRC@^1.0.1
+    plerup/EspSoftwareSerial@^8.1.0
+lib_ldf_mode = deep
+
+[env:pro16MHzatmega328]
+platform = atmelavr
+board = pro16MHzatmega328
+framework = arduino
+monitor_speed = 115200
+lib_extra_dirs = 
+    ..
+lib_deps = 
+    RobotReceiver
+    RobTillaart/CRC@^1.0.1    
 lib_ldf_mode = deep

--- a/lib/RobotSerial/src/RobotSerial.cpp
+++ b/lib/RobotSerial/src/RobotSerial.cpp
@@ -35,5 +35,8 @@ void RobotSerial::control(float* vec, uint16_t buttons)
     uint16_t crc = calcCRC16(buffer, 15, 0x8005, 0x0000, 0x0000, true, true);
     memcpy(buffer+15, &crc, sizeof(uint16_t));
     
-    _serial->write(buffer, 18);
+    if(_serial->availableForWrite() >= 18)
+    {
+        _serial->write(buffer, 18);
+    }
 }


### PR DESCRIPTION
また少しRobotReceiverとRobotSerialを変更しました

1. CRCチェックがうまく通らない件

　原因はRobotSerialが残っている通信バッファの量を気にせず書き込んだせいでなぜかたまたまCRCの位置だけ違う値が残るみたい
　 　https://github.com/DaiGuard/turret_mft2023/commit/a4cf58718e19e471e911833d9132381be796436a

　RobotReceiverも積極的にバッファを空にするように変更してました
　https://github.com/DaiGuard/turret_mft2023/commit/03b8d226056a7a36ddec16922a015f85d778b09d

2. サンプルコードのターゲットボード変更

　こいつはテスト用のサンプルコードをAE-ATMEGAでもビルドできるようにちょっと設定を追加しました
　https://github.com/DaiGuard/turret_mft2023/commit/c821d35a6e6a26fdd3bbad46116f2f92feaf3b50

3. ビルドワーニングの対応

　こいつはちょっとワーニングが出てただけだけどちょっと修正しました

プルリクよろしく！！